### PR TITLE
Delay recording processing after shutter sound

### DIFF
--- a/glive.py
+++ b/glive.py
@@ -349,7 +349,9 @@ class Glive:
         # pipeline while manipulating it.
         # http://dev.laptop.org/ticket/10183
         self._pipeline.set_state(gst.STATE_NULL)
-        self.model.shutter_sound()
+        self.model.shutter_sound(self._stop_recording_audio)
+
+    def _stop_recording_audio(self):
         self._pipeline.remove(self._audiobin)
 
         audio_path = os.path.join(Instance.instancePath, "output.wav")


### PR DESCRIPTION
Heavy processing by GStreamer of the audio recording pipeline interferes
with playing of the shutter sound effect.  One period of the sound (960
samples at 48000 Hz) is repeated for a time proportional to the
compression time of the recorded audio data, because GStreamer is too
busy to service the audio device.

Delay processing until the shutter sound effect completion callback
occurs.

Affects XO-1.75 with a recent kernel.

See also https://dev.laptop.org/ticket/12867#comment:10

Signed-off-by: James Cameron quozl@laptop.org
