### PR TITLE
Support wider aspect ratios

### DIFF
--- a/record.py
+++ b/record.py
@@ -579,9 +579,9 @@ class RecordContainer(gtk.Container):
     The controls hbox is given the first height that it requests, locked in
     for the duration of the widget.
     The media view is given the remainder of the space, but is constrained to
-    a strict 4:3 ratio, therefore deducing its width.
+    the aspect ratio of the display, therefore deducing its width.
     The controls hbox is given the same width, and both elements are centered
-    horizontall.y
+    horizontally.
     """
     __gtype_name__ = 'RecordContainer'
 
@@ -597,6 +597,9 @@ class RecordContainer(gtk.Container):
                 widget.set_parent_window(self.window)
 
             widget.set_parent(self)
+
+        ar = gdk.screen_width() * 100 / gdk.screen_height()
+        self._ar_legacy = ar < 134
 
     def do_realize(self):
         self.set_flags(gtk.REALIZED)
@@ -624,8 +627,11 @@ class RecordContainer(gtk.Container):
         pass
 
     def do_size_request(self, req):
-        # always request 320x240 (as a minimum for video)
-        req.width = 320
+        # always request a minimum for video
+        if self._ar_legacy:
+            req.width = 320
+        else:
+            req.width = 427
         req.height = 240
 
         self._media_view.size_request()
@@ -639,19 +645,24 @@ class RecordContainer(gtk.Container):
         req.height += self._controls_hbox_height
 
     @staticmethod
-    def _constrain_4_3(width, height):
-        if (width % 4 == 0) and (height % 3 == 0) and ((width / 4) * 3) == height:
+    def _constrain(width, height, ar_legacy):
+        if ar_legacy:
+            ax, ay = 4, 3
+        else:
+            ax, ay = 16, 9
+
+        if (width % ax == 0) and (height % ay == 0) and ((width / ax) * ay) == height:
             return width, height # nothing to do
 
-        ratio = 4.0 / 3.0
+        ratio = float(ax) / float(ay)
         if ratio * height > width:
-            width = (width / 4) * 4
+            width = (width / ax) * ax
             height = int(width / ratio)
         else:
-            height = (height / 3) * 3
+            height = (height / ay) * ay
             width = int(ratio * height)
 
-        return width, height 
+        return width, height
 
     @staticmethod
     def _center_in_plane(plane_size, size):
@@ -663,8 +674,8 @@ class RecordContainer(gtk.Container):
         # give the controls hbox the height that it requested
         remaining_height = self.allocation.height - self._controls_hbox_height
 
-        # give the mediaview the rest, constrained to 4/3 and centered
-        media_view_width, media_view_height = self._constrain_4_3(self.allocation.width, remaining_height)
+        # give the mediaview the rest, constrained to aspect ratio and centered
+        media_view_width, media_view_height = self._constrain(self.allocation.width, remaining_height, self._ar_legacy)
         media_view_x = self._center_in_plane(self.allocation.width, media_view_width)
         media_view_y = self._center_in_plane(remaining_height, media_view_height)
 

--- a/utils.py
+++ b/utils.py
@@ -56,7 +56,22 @@ def getUniqueFilepath( path, i ):
         return os.path.abspath( newPath )
 
 def generate_thumbnail(pixbuf):
-    return pixbuf.scale_simple(108, 81, gtk.gdk.INTERP_BILINEAR)
+    width = 108
+    height = 81
+
+    # scale to match available height, retaining aspect ratio
+    adjusted = height * pixbuf.get_width() / pixbuf.get_height()
+    scaled = pixbuf.scale_simple(adjusted, height, gtk.gdk.INTERP_BILINEAR)
+
+    # where aspect ratio is conventional, e.g. 4:3, return scaled image
+    if adjusted == width:
+        return scaled
+
+    # where aspect ratio is unconventional, e.g. 16:9, trim sides
+    trimmed = gtk.gdk.Pixbuf(scaled.get_colorspace(), scaled.get_has_alpha(),
+                             scaled.get_bits_per_sample(), width, height)
+    scaled.copy_area((adjusted - width) / 2, 0, width, height, trimmed, 0, 0)
+    return trimmed
 
 def getDateString( when ):
     return strftime( "%c", time.localtime(when) )


### PR DESCRIPTION
Displays with wider aspect ratios of 16:9 gave squashed thumbnails and photograph views, because the activity assumed a 4:3 aspect ratio.

When a photograph was taken, the thumbnail image was shown squashed, people were tall and thin.  When a photograph was selected from the tray, the same effect was shown in the media view.  The live camera view was also smaller than it could be.

Fix is to;
- detect the display aspect ratio, and use it for sizing the media view widget, and;
- detect the camera aspect ratio, and trim sides of image to fit our 4:3 thumbnail SVG template.

Fixes most but not all of https://bugs.sugarlabs.org/ticket/4860

Tested on
- OLPC XO-4 (aspect ratio 4:3, Fedora 18), and;
- OLPC XO laptop SKU400 (aspect ratio 16:9, Ubuntu 16.04).
